### PR TITLE
feat(nb_store): 过滤依赖类型插件

### DIFF
--- a/nb_store/__init__.py
+++ b/nb_store/__init__.py
@@ -24,7 +24,7 @@ __plugin_meta__ = PluginMetadata(
     """.strip(),
     extra=PluginExtraData(
         author="molanp",
-        version="0.2",
+        version="0.3",
         plugin_type=PluginType.SUPERUSER,
     ).to_dict(),
 )

--- a/nb_store/data_source.py
+++ b/nb_store/data_source.py
@@ -87,7 +87,13 @@ class StoreManager:
         response = await AsyncHttpx.get(PLUGIN_INDEX, check_status_code=200)
         if response.status_code == 200:
             logger.info("获取nb插件列表成功", LOG_COMMAND)
-            return [StorePluginInfo(**detail) for detail in json.loads(response.text)]
+            data = []
+            data.extend(
+                StorePluginInfo(**detail)
+                for detail in json.loads(response.text)
+                if detail.get("type") != "library"
+            )
+            return data
         else:
             logger.warning(f"获取nb插件列表失败: {response.status_code}", LOG_COMMAND)
         return []


### PR DESCRIPTION
- 将插件版本从 0.2 升级到 0.3
- 在获取 nb 插件列表时，过滤掉类型为 "library" 的插件

## Sourcery 总结

将 nb_store 插件升级到 0.3 版本，并在获取插件列表时过滤掉库类型插件

新功能：
- 从商店插件列表中排除类型为 'library' 的插件

改进：
- 将 nb_store 插件版本从 0.2 提升到 0.3

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade nb_store plugin to version 0.3 and filter out library-type plugins when fetching the plugin list

New Features:
- Exclude plugins with type 'library' from the store plugin listing

Enhancements:
- Bump nb_store plugin version from 0.2 to 0.3

</details>