### PR TITLE
feat(nb_store): 增强插件商店功能并优化用户体验

### DIFF
--- a/nb_store/__init__.py
+++ b/nb_store/__init__.py
@@ -1,13 +1,19 @@
 from nonebot.permission import SUPERUSER
 from nonebot.plugin import PluginMetadata
-from nonebot_plugin_alconna import Alconna, Args, Match, Subcommand, on_alconna
+from nonebot_plugin_alconna import (
+    Alconna,
+    Args,
+    Match,
+    Option,
+    Subcommand,
+    on_alconna,
+)
 from nonebot_plugin_session import EventSession
 
 from zhenxun.configs.utils import PluginExtraData
 from zhenxun.services.log import logger
 from zhenxun.utils.enum import PluginType
 from zhenxun.utils.message import MessageUtils
-from zhenxun.utils.utils import is_number
 
 from .data_source import StoreManager
 
@@ -15,16 +21,17 @@ __plugin_meta__ = PluginMetadata(
     name="Nonebot插件商店",
     description="Nonebot插件商店",
     usage="""
-    nb商店 ?页码 ?每页项数        : 查看当前的nonebot 插件商店
-    添加nb插件 id/name/pypi_name     : 添加nonebot 市场插件
-    移除nb插件 id/name/pypi_name     : 移除nonebot 市场插件
+    nb商店 ?页码 ?每页项数 <?-o> xx : 查看当前的nonebot 插件商店.使用参数 -o 指定排序字段
+    添加nb插件 name/pypi_name     : 添加nonebot 市场插件
+    移除nb插件 name/pypi_name     : 移除nonebot 市场插件
     搜索nb插件 <任意关键字>     : 搜索nonebot 市场插件
-    更新nb插件 id/name/pypi_name     : 更新nonebot 市场插件
-    更新全部nb插件     : 更新全部nonebot 市场插件
+    更新nb插件 name/pypi_name     : 更新nonebot 市场插件
+    查看可更新nb插件 ?页码 ?每页项数 <?-o> xx : 查看可更新nonebot 市场插件.使用参数 -o 指定排序字段
+    更新全部nb插件          : 更新全部nonebot 市场插件
     """.strip(),
     extra=PluginExtraData(
         author="molanp",
-        version="0.3",
+        version="0.4",
         plugin_type=PluginType.SUPERUSER,
     ).to_dict(),
 )
@@ -32,12 +39,17 @@ __plugin_meta__ = PluginMetadata(
 _matcher = on_alconna(
     Alconna(
         "nb商店",
-        Args["page?", int, 1],
-        Args["page_size?", int, 20],
+        Args["page?", int, 1]["page_size?", int, 20],
+        Option(
+            "-o|--order",
+            Args["order_by", str, "time"],
+            help_text="排序标准，默认为更新时间",
+        ),
         Subcommand("add", Args["plugin_id", str]),
         Subcommand("remove", Args["plugin_id", str]),
         Subcommand("search", Args["plugin_name_or_author", str]),
         Subcommand("update", Args["plugin_id", str]),
+        Subcommand("can_update"),
         Subcommand("update_all"),
     ),
     permission=SUPERUSER,
@@ -74,6 +86,13 @@ _matcher.shortcut(
 )
 
 _matcher.shortcut(
+    r"查看可更新nb插件",
+    command="nb商店",
+    arguments=["can_update"],
+    prefix=True,
+)
+
+_matcher.shortcut(
     r"更新全部nb插件",
     command="nb商店",
     arguments=["update_all"],
@@ -82,30 +101,37 @@ _matcher.shortcut(
 
 
 @_matcher.assign("$main")
-async def _(session: EventSession, page: Match[int], page_size: Match[int]):
+async def _(
+    session: EventSession,
+    page: Match[int],
+    page_size: Match[int],
+    order_by: Match[str],
+):
+    _order_by = order_by.result if order_by.available else "time"
     try:
-        result = await StoreManager.get_plugins_by_page(page.result, page_size.result)
-        logger.info("查看插件列表", "nb商店", session=session)
+        result = await StoreManager.get_plugins_by_page(
+            page.result, page_size.result, _order_by
+        )
+        logger.info(
+            f"查看插件列表 orber_by: {_order_by}",
+            "nb商店",
+            session=session,
+        )
         await MessageUtils.build_message(result).send()
     except Exception as e:
-        logger.error(f"查看插件列表失败 e: {e}", "nb商店", session=session, e=e)
+        logger.error("查看插件列表失败", "nb商店", session=session, e=e)
         await MessageUtils.build_message("获取插件列表失败...").send()
 
 
 @_matcher.assign("add")
 async def _(session: EventSession, plugin_id: str):
     try:
-        if is_number(plugin_id):
-            await MessageUtils.build_message(f"正在添加插件 Id: {plugin_id}").send()
-        else:
-            await MessageUtils.build_message(f"正在添加插件: {plugin_id}").send()
+        await MessageUtils.build_message(f"正在添加插件: {plugin_id}").send()
         result = await StoreManager.add_plugin(plugin_id)
     except Exception as e:
-        logger.error(f"添加插件 Id: {plugin_id}失败", "nb商店", session=session, e=e)
-        await MessageUtils.build_message(
-            f"添加插件 Id: {plugin_id} 失败 e: {e}"
-        ).finish()
-    logger.info(f"添加插件 Id: {plugin_id}", "nb商店", session=session)
+        logger.error(f"添加插件 {plugin_id}失败", "nb商店", session=session, e=e)
+        await MessageUtils.build_message(f"添加插件 {plugin_id} 失败 e: {e}").finish()
+    logger.info(f"添加插件 {plugin_id}", "nb商店", session=session)
     await MessageUtils.build_message(result).send()
 
 
@@ -114,18 +140,25 @@ async def _(session: EventSession, plugin_id: str):
     try:
         result = await StoreManager.remove_plugin(plugin_id)
     except Exception as e:
-        logger.error(f"移除插件 Id: {plugin_id}失败", "nb商店", session=session, e=e)
-        await MessageUtils.build_message(
-            f"移除插件 Id: {plugin_id} 失败 e: {e}"
-        ).finish()
-    logger.info(f"移除插件 Id: {plugin_id}", "nb商店", session=session)
+        logger.error(f"移除插件 {plugin_id}失败", "nb商店", session=session, e=e)
+        await MessageUtils.build_message(f"移除插件 {plugin_id} 失败 e: {e}").finish()
+    logger.info(f"移除插件 {plugin_id}", "nb商店", session=session)
     await MessageUtils.build_message(result).send()
 
 
 @_matcher.assign("search")
-async def _(session: EventSession, plugin_name_or_author: str):
+async def _(
+    session: EventSession,
+    plugin_name_or_author: str,
+    page: Match[int],
+    page_size: Match[int],
+    order_by: Match[str],
+):
+    _order_by = order_by.result if order_by.available else "time"
     try:
-        result = await StoreManager.search_plugin(plugin_name_or_author)
+        result = await StoreManager.get_plugins_by_page(
+            page.result, page_size.result, _order_by, query=plugin_name_or_author
+        )
     except Exception as e:
         logger.error(
             f"搜索插件 name: {plugin_name_or_author}失败",
@@ -143,17 +176,31 @@ async def _(session: EventSession, plugin_name_or_author: str):
 @_matcher.assign("update")
 async def _(session: EventSession, plugin_id: str):
     try:
-        if is_number(plugin_id):
-            await MessageUtils.build_message(f"正在更新插件 Id: {plugin_id}").send()
-        else:
-            await MessageUtils.build_message(f"正在更新插件 Module: {plugin_id}").send()
+        await MessageUtils.build_message(f"正在更新插件 {plugin_id}").send()
         result = await StoreManager.update_plugin(plugin_id)
     except Exception as e:
-        logger.error(f"更新插件 Id: {plugin_id}失败", "nb商店", session=session, e=e)
-        await MessageUtils.build_message(
-            f"更新插件 Id: {plugin_id} 失败 e: {e}"
-        ).finish()
-    logger.info(f"更新插件 Id: {plugin_id}", "nb商店", session=session)
+        logger.error(f"更新插件 {plugin_id}失败", "nb商店", session=session, e=e)
+        await MessageUtils.build_message(f"更新插件 {plugin_id} 失败 e: {e}").finish()
+    logger.info(f"更新插件 {plugin_id}", "nb商店", session=session)
+    await MessageUtils.build_message(result).send()
+
+
+@_matcher.assign("can_update")
+async def _(
+    session: EventSession,
+    page: Match[int],
+    page_size: Match[int],
+    order_by: Match[str],
+):
+    _order_by = order_by.result if order_by.available else "time"
+    try:
+        result = await StoreManager.get_plugins_by_page(
+            page.result, page_size.result, _order_by, True
+        )
+    except Exception as e:
+        logger.error("查看可更新插件失败", "nb商店", session=session, e=e)
+        await MessageUtils.build_message(f"查看可更新插件失败 e: {e}").finish()
+    logger.info("查看可更新插件", "nb商店", session=session)
     await MessageUtils.build_message(result).send()
 
 

--- a/nb_store/__init__.py
+++ b/nb_store/__init__.py
@@ -24,7 +24,7 @@ __plugin_meta__ = PluginMetadata(
     nb商店 ?页码 ?每页项数 <?-o> xx : 查看当前的nonebot 插件商店.使用参数 -o 指定排序字段
     添加nb插件 name/pypi_name     : 添加nonebot 市场插件
     移除nb插件 name/pypi_name     : 移除nonebot 市场插件
-    搜索nb插件 <任意关键字>     : 搜索nonebot 市场插件
+    搜索nb插件 <任意关键字>  ?页码 ?每页项数 <?-o> xx     : 搜索nonebot 市场插件.使用参数 -o 指定排序字段
     更新nb插件 name/pypi_name     : 更新nonebot 市场插件
     查看可更新nb插件 ?页码 ?每页项数 <?-o> xx : 查看可更新nonebot 市场插件.使用参数 -o 指定排序字段
     更新全部nb插件          : 更新全部nonebot 市场插件

--- a/nb_store/models.py
+++ b/nb_store/models.py
@@ -1,5 +1,14 @@
+from datetime import datetime
+
 from nonebot.compat import model_dump
 from pydantic import BaseModel
+
+
+class TagDetail(BaseModel):
+    label: str
+    """标签名称"""
+    color: str
+    """十六进制标签颜色"""
 
 
 class StorePluginInfo(BaseModel):
@@ -13,12 +22,18 @@ class StorePluginInfo(BaseModel):
     """pypi包名"""
     desc: str
     """简介"""
-    tags: list[dict[str, str]] = []
+    tags: list[TagDetail] = []
     """标签"""
     author: str
     """作者"""
     version: str
     """版本"""
+    is_official: bool
+    """是否为官方插件"""
+    time: datetime
+    """更新时间"""
+    valid: bool
+    """是否通过商店测试"""
 
     def to_dict(self, **kwargs):
         return model_dump(self, **kwargs)


### PR DESCRIPTION
- 添加插件排序功能，支持按时间、名称等字段排序
- 新增查看可更新插件功能
- 优化插件搜索逻辑，支持模糊匹配
- 调整插件安装、卸载和更新流程
- 修复部分已知问题

## Sourcery 总结

增强插件商店，增加排序、模糊搜索和可更新插件列表功能，重构管理命令以实现统一接口，丰富插件元数据，并将版本提升至 0.4。

新功能：
- 通过 `-o/--order` 选项，增加按字段（时间、名称等）排序插件的功能
- 增加新的 `can_update` 子命令，支持仅查看可更新插件
- 在主列表中支持对插件名称、作者和描述进行模糊搜索
- 在插件列表显示中包含商店测试状态和最后更新时间列

错误修复：
- 修复商店测试状态列的行样式着色逻辑
- 修正版本检查的文档字符串，以反映其真/假逻辑

改进：
- 重构 `get_plugins_by_page` 函数，以结合过滤、排序和仅更新视图
- 简化插件查找并移除已弃用的 `search_plugin` 方法
- 扩展 `StorePluginInfo` 模型，增加 `is_official`、`time`、`valid` 和结构化的 `TagDetail` 元数据
- 统一 `add`、`remove`、`update` 和 `search` 流程中的命令选项解析和错误处理
- 将插件版本提升至 0.4 并相应更新使用说明

文档：
- 更新 README 和命令用法，以包含排序标志和新的子命令

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the plugin store with sorting, fuzzy search, and updatable-plugin listing, refactor management commands for a unified interface, enrich plugin metadata, and bump version to 0.4

New Features:
- Add plugin sorting by fields (time, name, etc.) via -o/--order option
- Enable viewing only updatable plugins with new 'can_update' subcommand
- Support fuzzy search on plugin name, author, and description within the main listing
- Include store test status and last update time columns in the plugin list display

Bug Fixes:
- Fix row style coloring logic for the store test status column
- Correct version check docstring to reflect true/false logic

Enhancements:
- Refactor get_plugins_by_page to combine filtering, sorting, and update-only views
- Simplify plugin lookup and remove deprecated search_plugin method
- Extend StorePluginInfo model with is_official, time, valid, and structured TagDetail metadata
- Unify command option parsing and error handling across add, remove, update, and search flows
- Bump plugin version to 0.4 and update usage instructions accordingly

Documentation:
- Update README and command usage to include sorting flag and new subcommands

</details>